### PR TITLE
Recursion in statement

### DIFF
--- a/src/main/scala/myMix/Account.scala
+++ b/src/main/scala/myMix/Account.scala
@@ -4,16 +4,18 @@ import java.time.LocalDate
 import scala.collection.mutable.ArrayBuffer
 
 class Account {
-  var balance = 0.0
   var transactions: ArrayBuffer[Transaction] = ArrayBuffer()
+  def balance {
+    transactions.map(txn => txn.getAmount).sum
+  }
 
   def deposit(amount: Double, date: LocalDate): Unit = {
-    balance += amount
     transactions += new Transaction(amount, date)
+    balance
   }
 
   def withdraw(amount: Double, date: LocalDate): Unit = {
-    balance -= amount
     transactions += new Transaction(-amount, date)
+    balance
   }
 }

--- a/src/main/scala/myMix/StatementFormatter.scala
+++ b/src/main/scala/myMix/StatementFormatter.scala
@@ -13,30 +13,25 @@ class StatementFormatter{
     }else{
       StatementHeader
     }
-
-  }
-  private def sortTransactions(txns: Seq[Transaction]) =
-    txns.sortBy(tx => tx.getDate)
-
-  //I don't understand the syntax used here.
-  //is it like 2 functions running on a
-  //conditional depending on the params passed?
-  private def formatTransactions: Double => Seq[Transaction] => String = (startingBalance: Double) => {
-    case Nil => ""
-    case tx :: txs =>
-      formatTransactions(startingBalance + tx.getAmount)(txs)
-        .concat(formatLine(tx.getAmount, tx.getDate, startingBalance + tx.getAmount))
   }
 
-  //TODO the count here is indexing wrong -> figure out where it's going wrong
+  //TODO this is not functioning correctly.
+  private def sortTransactions(txns: Seq[Transaction]) = txns.sortBy(tx => tx.getDate)
+
   @tailrec
   private def newFormatter(transactions: Seq[Transaction], thisString: String = "", count: Int = 0, startingBalance: Double = 0): String ={
     val newCount = count + 1
-    val currentTxn = transactions(count)
     if(count == transactions.length){
       thisString
     }else{
-      val newString = s"$thisString\n${currentTxn.getAmount}, ${currentTxn.getDate}, ${currentTxn.getAmount + startingBalance}"
+      val currentTxn = transactions(count)
+      val newString = {
+        if(thisString.length > 0){
+          s"\n$thisString\n${currentTxn.getAmount},${currentTxn.getDate},${currentTxn.getAmount + startingBalance}"
+        }else{
+          s"${currentTxn.getAmount},${currentTxn.getDate},${currentTxn.getAmount + startingBalance}"
+        }
+      }
       newFormatter(transactions = transactions,thisString = newString, count = newCount, startingBalance = startingBalance+currentTxn.getAmount)
     }
   }

--- a/src/main/scala/myMix/StatementFormatter.scala
+++ b/src/main/scala/myMix/StatementFormatter.scala
@@ -16,7 +16,7 @@ class StatementFormatter{
   }
 
   //TODO this is not functioning correctly.
-  private def sortTransactions(txns: Seq[Transaction]) = txns.sortBy(tx => tx.getDate)
+  private def sortTransactions(txns: Seq[Transaction]): Seq[Transaction] = txns.sortBy(tx => tx.getDate).reverse
 
   @tailrec
   private def newFormatter(transactions: Seq[Transaction], thisString: String = "", count: Int = 0, startingBalance: Double = 0): String ={
@@ -27,7 +27,7 @@ class StatementFormatter{
       val currentTxn = transactions(count)
       val newString = {
         if(thisString.length > 0){
-          s"\n$thisString\n${currentTxn.getAmount},${currentTxn.getDate},${currentTxn.getAmount + startingBalance}"
+          s"$thisString\n${currentTxn.getAmount},${currentTxn.getDate},${currentTxn.getAmount + startingBalance}"
         }else{
           s"${currentTxn.getAmount},${currentTxn.getDate},${currentTxn.getAmount + startingBalance}"
         }

--- a/src/main/scala/myMix/StatementFormatter.scala
+++ b/src/main/scala/myMix/StatementFormatter.scala
@@ -1,21 +1,44 @@
 package myMix
 
+import scala.annotation.tailrec
+
 class StatementFormatter{
   val StatementHeader: String = formatLine("Amount", "Date", "Balance")
 
-  def format: Seq[Transaction] => String =
-    sortTransactions _ andThen
-      formatTransactions(0) andThen
-      addHeader
+  def format(transactions: Seq[Transaction]): String = {
+    if(transactions.length > 0){
+      val sorted = sortTransactions(transactions)
+      val formatted = newFormatter(sorted)
+      addHeader(formatted)
+    }else{
+      StatementHeader
+    }
 
+  }
   private def sortTransactions(txns: Seq[Transaction]) =
     txns.sortBy(tx => tx.getDate)
 
+  //I don't understand the syntax used here.
+  //is it like 2 functions running on a
+  //conditional depending on the params passed?
   private def formatTransactions: Double => Seq[Transaction] => String = (startingBalance: Double) => {
     case Nil => ""
     case tx :: txs =>
       formatTransactions(startingBalance + tx.getAmount)(txs)
         .concat(formatLine(tx.getAmount, tx.getDate, startingBalance + tx.getAmount))
+  }
+
+  //TODO the count here is indexing wrong -> figure out where it's going wrong
+  @tailrec
+  private def newFormatter(transactions: Seq[Transaction], thisString: String = "", count: Int = 0, startingBalance: Double = 0): String ={
+    val newCount = count + 1
+    val currentTxn = transactions(count)
+    if(count == transactions.length){
+      thisString
+    }else{
+      val newString = s"$thisString\n${currentTxn.getAmount}, ${currentTxn.getDate}, ${currentTxn.getAmount + startingBalance}"
+      newFormatter(transactions = transactions,thisString = newString, count = newCount, startingBalance = startingBalance+currentTxn.getAmount)
+    }
   }
 
   private def addHeader(formattedTxns: String): String = StatementHeader.concat(formattedTxns)

--- a/src/main/scala/myMix/StatementFormatter.scala
+++ b/src/main/scala/myMix/StatementFormatter.scala
@@ -16,7 +16,7 @@ class StatementFormatter{
   }
 
   //TODO this is not functioning correctly.
-  private def sortTransactions(txns: Seq[Transaction]): Seq[Transaction] = txns.sortBy(tx => tx.getDate).reverse
+  private def sortTransactions(txns: Seq[Transaction]): Seq[Transaction] = txns.sortBy(tx => tx.getDate)
 
   @tailrec
   private def newFormatter(transactions: Seq[Transaction], thisString: String = "", count: Int = 0, startingBalance: Double = 0): String ={

--- a/src/test/scala/StatementFormatterTest.scala
+++ b/src/test/scala/StatementFormatterTest.scala
@@ -13,6 +13,7 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       val acc = new Account
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
+      println(s"contains heads test: $formattedStatement")
       assert(formattedStatement.contains("Amount,Date,Balance"))
     }
 
@@ -21,6 +22,7 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       acc.deposit(5.0, testDate)
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
+      println(s"formatting test: $formattedStatement")
       assert(formattedStatement.contains(s"Amount,Date,Balance\n5.0,$testDate,5.0"))
     }
 
@@ -31,6 +33,7 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       acc.deposit(50.0, oldDate)
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
+      println(s"order transactions by date: $formattedStatement")
       assert(formattedStatement.contains(f"""|Amount,Date,Balance
                                              |5.0,$testDate,55.0
                                              |50.0,$oldDate,50.0""".stripMargin))

--- a/src/test/scala/StatementFormatterTest.scala
+++ b/src/test/scala/StatementFormatterTest.scala
@@ -13,7 +13,6 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       val acc = new Account
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
-      println(s"contains heads test: $formattedStatement")
       assert(formattedStatement.contains("Amount,Date,Balance"))
     }
 
@@ -22,21 +21,27 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       acc.deposit(5.0, testDate)
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
-      println(s"formatting test: $formattedStatement")
       assert(formattedStatement.contains(s"Amount,Date,Balance\n5.0,$testDate,5.0"))
     }
 
     "Order transactions by date" in {
-      val oldDate = LocalDate.parse("2012-08-02")
+      val date2 = LocalDate.parse("2012-08-02")
+      val date3 = LocalDate.parse("2011-01-01")
+      val date4 = LocalDate.parse("2010-01-01")
       val acc = new Account
+      acc.withdraw(1, date4)
+      acc.deposit(1,date3)
+      acc.deposit(50.0, date2)
       acc.deposit(5.0, testDate)
-      acc.deposit(50.0, oldDate)
       val newStatement = new StatementFormatter
       val formattedStatement = newStatement.format(acc.transactions.toSeq)
-      println(s"order transactions by date: $formattedStatement")
+      println(formattedStatement)
+      println(acc.balance)
       assert(formattedStatement.contains(f"""|Amount,Date,Balance
                                              |5.0,$testDate,55.0
-                                             |50.0,$oldDate,50.0""".stripMargin))
+                                             |50.0,$date2,50.0
+                                             |-1.0, $date3,0.0
+                                             |1.0, $date4, 1.0""".stripMargin))
     }
   }
 }

--- a/src/test/scala/StatementFormatterTest.scala
+++ b/src/test/scala/StatementFormatterTest.scala
@@ -29,8 +29,8 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       val date3 = LocalDate.parse("2011-01-01")
       val date4 = LocalDate.parse("2010-01-01")
       val acc = new Account
-      acc.withdraw(1, date4)
-      acc.deposit(1,date3)
+      acc.deposit(1,date4)
+      acc.withdraw(1, date3)
       acc.deposit(50.0, date2)
       acc.deposit(5.0, testDate)
       val newStatement = new StatementFormatter
@@ -38,10 +38,10 @@ class StatementFormatterTest extends AnyWordSpec with Matchers {
       println(formattedStatement)
       println(acc.balance)
       assert(formattedStatement.contains(f"""|Amount,Date,Balance
-                                             |5.0,$testDate,55.0
+                                             |1.0,$date4,1.0
+                                             |-1.0,$date3,0.0
                                              |50.0,$date2,50.0
-                                             |-1.0, $date3,0.0
-                                             |1.0, $date4, 1.0""".stripMargin))
+                                             |5.0,$testDate,55.0""".stripMargin))
     }
   }
 }


### PR DESCRIPTION
even though the date sorting isn't properly working in this current state I believe this branch has served it's purpose of improving the recursion in StatementFormatter -> from standard recursion to tailrec.